### PR TITLE
Improve README with links to the backend quickstarts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Welcome to the Sync Demo application.  This application demonstrates a basic Tic
 What you'll minimally need to get started:
 
 - A clone of this repository
-- [A way to create a Sync Service Instance and generate client tokens](https://www.twilio.com/docs/api/sync/identity-and-access-tokens)
-- Gradle installation
+- A running instance of the backend quickstart of your choice ([Ruby](https://github.com/TwilioDevEd/sync-quickstart-ruby), [Python](https://github.com/TwilioDevEd/sync-quickstart-python), [Node.js](https://github.com/TwilioDevEd/sync-quickstart-node), [Java](https://github.com/TwilioDevEd/sync-quickstart-java), [C#](https://github.com/TwilioDevEd/sync-quickstart-csharp), or [PHP](https://github.com/TwilioDevEd/sync-quickstart-php)) to issue [Access Tokens](https://www.twilio.com/docs/api/sync/identity-and-access-tokens)
+- A functioning Gradle installation
 
 ## Building
 
@@ -19,22 +19,24 @@ Run
 ./gradlew wrapper
 ```
 
-### Set the value of `SERVER_TOKEN_URL`
+### Wire in your Token Service
 
-Set the value of `SERVER_TOKEN_URL` in sync-quickstart-android/gradle.properties file to point to a valid Access-Token server.
+Set the value of `SERVER_TOKEN_URL` in sync-quickstart-android/gradle.properties file to point to a valid Access-Token server. If you're using one of the quickstarts to provide tokens, you'll probably want to use [`ngrok`](http://ngrok.io) to direct a publicly-accessible URL to your localhost service.
 
-Create that file if it doesn't exist with the following contents:
-
-```
-SERVER_TOKEN_URL=http://myserver.com/get-token/
+```bash
+$ ngrok http localhost:4567
 ```
 
-NOTE: no need for quotes around the URL, they will be added automatically.
-
-You can also pass this parameter to gradle during build without need to create a properties file, as follows:
+Your `gradle.properties` file should look something like this, borrowing from the output of the above.
 
 ```
-gradle -PSERVER_TOKEN_URL=http://myserver.com/get-token/ build
+SERVER_TOKEN_URL=http://9349392.ngrok.io/token
+```
+
+You can also pass this address to gradle during the build.
+
+```bash
+$ gradle -PSERVER_TOKEN_URL=http://9349392.ngrok.io/token build
 ```
 
 ### Build
@@ -43,4 +45,4 @@ Run `gradle build` to fetch Twilio Sync SDK files and build application.
 
 ### Android Studio
 
-You can import this project into Android Studio if you so desire by selecting `Import Project (Eclipse ADT, Gradle, etc)` from the menu and then build using Studio's Build menu.
+You can import this project into Android Studio if you so desire by selecting `Import Project (Eclipse ADT, Gradle, etc)` from the menu and then build as you would ordinarily. The token server setup is still important.


### PR DESCRIPTION
The Android quickstart code was changed to assume one of the backend quickstarts, so I made this assumption part of the readme.